### PR TITLE
Fixing broken redirect page by removing unhandled exception

### DIFF
--- a/Controller/Payment/Cancel.php
+++ b/Controller/Payment/Cancel.php
@@ -12,7 +12,6 @@ use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\Result\Redirect;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Controller\ResultInterface;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
 

--- a/Gateway/Command/CancelStrategyCommand.php
+++ b/Gateway/Command/CancelStrategyCommand.php
@@ -8,7 +8,6 @@ use Anyday\PaymentAndTrack\Gateway\Exception\NoData;
 use Anyday\PaymentAndTrack\Gateway\Exception\PaymentException;
 use Magento\Payment\Gateway\Command;
 use Magento\Sales\Api\Data\TransactionInterface;
-use Magento\Sales\Model\Order\Payment;
 use Magento\Sales\Model\Order\Payment\Transaction;
 
 class CancelStrategyCommand extends AbstractStrategyCommand
@@ -50,8 +49,6 @@ class CancelStrategyCommand extends AbstractStrategyCommand
                 $result = $this->curlAnyday->request();
                 if ($result['errorCode'] == 0) {
                     break;
-                } else {
-                    throw new PaymentException(__($result['errorMessage']));
                 }
             }
         }


### PR DESCRIPTION
When the payment is cancelled or rejected from Anyday, It redirects to broken page in Magento.

<img width="1064" alt="Screenshot 2021-08-23 at 5 37 31 AM" src="https://user-images.githubusercontent.com/5526195/130372273-5735abbb-71f5-4fab-ade3-15031633efbd.png">
